### PR TITLE
Remove need for debug module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 var request = require('request');
 var qs = require('qs');
-var debug = require('debug')('app:sdk');
-
+try {
+  var debug = require('debug')('app:sdk');
+} catch(err) {
+  debug = function() { };
+}
 var Youtube = function() {
   var ENDPOINT = 'https://www.googleapis.com/youtube/v3/';
   var KEY = null;


### PR DESCRIPTION
The module `debug` is on devDependencies so it will not install when installed as a dependency. I added code to avoid to have to install it manually.
